### PR TITLE
Allow durability, reliability, and history to optionally be specified for subscriptions

### DIFF
--- a/src/RosNode.ts
+++ b/src/RosNode.ts
@@ -94,6 +94,9 @@ export class RosNode extends EventEmitter<RosNodeEvents> {
     if (typeName == undefined) {
       throw new Error(`Invalid dataType "${options.dataType}"`);
     }
+    if (options.reliability?.kind === Reliability.BestEffort) {
+      throw new Error(`BestEffort reliability is not supported yet`);
+    }
 
     // Check if we are already subscribed
     let subscription = this.subscriptions.get(options.topic);
@@ -106,9 +109,12 @@ export class RosNode extends EventEmitter<RosNodeEvents> {
     const rtpsOpts = {
       topicName,
       typeName,
-      durability: Durability.TransientLocal,
-      reliability: { kind: Reliability.Reliable, maxBlockingTime: DURATION_INFINITE },
-      history: { kind: HistoryKind.KeepLast, depth: 1 },
+      durability: options.durability ?? Durability.TransientLocal,
+      reliability: options.reliability ?? {
+        kind: Reliability.Reliable,
+        maxBlockingTime: DURATION_INFINITE,
+      },
+      history: options.history ?? { kind: HistoryKind.KeepLast, depth: 1 },
     };
 
     this._log?.debug?.(`subscribing to ${options.topic} (${options.dataType})`);

--- a/src/Subscription.ts
+++ b/src/Subscription.ts
@@ -2,11 +2,14 @@ import { RosMsgDefinition } from "@foxglove/rosmsg";
 import { MessageReader } from "@foxglove/rosmsg2-serialization";
 import { Time, fromDate } from "@foxglove/rostime";
 import {
+  Durability,
   EndpointAttributes,
   EntityId,
   Guid,
+  HistoryAndDepth,
   makeGuid,
   Participant,
+  ReliabilityAndMaxBlockingTime,
   SubscribeOpts as RtpsSubscribeOpts,
   subscriptionMatchesPublication,
 } from "@foxglove/rtps";
@@ -15,6 +18,9 @@ import { EventEmitter } from "eventemitter3";
 export type SubscribeOpts = {
   topic: string;
   dataType: string;
+  durability?: Durability;
+  reliability?: ReliabilityAndMaxBlockingTime;
+  history?: HistoryAndDepth;
   msgDefinition?: RosMsgDefinition[];
   skipParsing?: boolean;
 };


### PR DESCRIPTION
Addresses https://github.com/foxglove/ros2/issues/92 by allowing subscribers to specify the durability, reliability, and/or history options they want for the subscription. Waiting for a topic advertisement and extracting the correct subscription parameters from it is out of scope for this library and should be handled by higher-level code.

Adding an example that does the correct thing would be a welcome follow-up.