### PR TITLE
change default qos to volatile and best effort

### DIFF
--- a/src/RosNode.ts
+++ b/src/RosNode.ts
@@ -187,9 +187,6 @@ export class RosNode extends EventEmitter<RosNodeEvents> {
     if (typeName == undefined) {
       throw new Error(`Invalid dataType "${options.dataType}"`);
     }
-    if (options.reliability?.kind === Reliability.BestEffort) {
-      throw new Error(`BestEffort reliability is not supported yet`);
-    }
 
     // Check if we are already subscribed
     let subscription = this.subscriptions.get(options.topic);
@@ -202,9 +199,9 @@ export class RosNode extends EventEmitter<RosNodeEvents> {
     const rtpsOpts = {
       topicName,
       typeName,
-      durability: options.durability ?? Durability.TransientLocal,
+      durability: options.durability ?? Durability.Volatile,
       reliability: options.reliability ?? {
-        kind: Reliability.Reliable,
+        kind: Reliability.BestEffort,
         maxBlockingTime: DURATION_INFINITE,
       },
       history: options.history ?? { kind: HistoryKind.KeepLast, depth: 1 },


### PR DESCRIPTION
**Public-Facing Changes**
<!-- describe any changes to the public interface or APIs, or write "None" -->
"None"


**Description**
<!-- describe what has changed, and motivation behind those changes -->
change default qos(reliability: reliable->best_effrot, durability: transient_local->volatile)
because best effort and volatile are always compatible with any publisher qos.
https://docs.ros.org/en/rolling/Concepts/About-Quality-of-Service-Settings.html
I confirmed the default qos is changed when testing with `yarn examples:listener`.
```
❯ yarn examples:listener
❯ ros2 run demo_nodes_cpp talker
❯ ros2 topic info -v /chatter
Type: std_msgs/msg/String

Publisher count: 1

Node name: talker
Node namespace: /
Topic type: std_msgs/msg/String
Endpoint type: PUBLISHER
GID: 01.0f.08.ae.fc.42.76.e3.01.00.00.00.00.00.12.03.00.00.00.00.00.00.00.00
QoS profile:
  Reliability: RELIABLE
  History (Depth): UNKNOWN
  Durability: VOLATILE
  Lifespan: Infinite
  Deadline: Infinite
  Liveliness: AUTOMATIC
  Liveliness lease duration: Infinite

Subscription count: 1

Node name: _NODE_NAME_UNKNOWN_
Node namespace: _NODE_NAMESPACE_UNKNOWN_
Topic type: std_msgs/msg/String
Endpoint type: SUBSCRIPTION
GID: 62.d9.27.c1.f4.5d.2b.b8.0c.e8.0d.34.00.00.01.04.00.00.00.00.00.00.00.00
QoS profile:
  Reliability: BEST_EFFORT
  History (Depth): UNKNOWN
  Durability: VOLATILE
  Lifespan: Infinite
  Deadline: Infinite
  Liveliness: AUTOMATIC
  Liveliness lease duration: Infinite
```


<!-- link relevant GitHub issues -->
https://github.com/foxglove/studio/issues/2871
